### PR TITLE
Fix hiworkload backport

### DIFF
--- a/kgr_tc_workload.sh
+++ b/kgr_tc_workload.sh
@@ -54,9 +54,9 @@ function workload_mem {
     local chimem_bin="$SOURCE_DIR/hiworkload/src/chimem"
 
     if [ ! -x "$chimem_bin" ]; then
-        klp_tc_milestone "chimem binary is missing, compile it"
+        kgr_tc_milestone "chimem binary is missing, compile it"
         cd $SOURCE_DIR/hiworkload
-        ./compile.sh || klp_tc_abort "failed to compile chimem"
+        ./compile.sh || kgr_tc_abort "failed to compile chimem"
         cd -
     fi
 


### PR DESCRIPTION
s/klp_/kgr_/

Fixes: 589c77f Backport hiworkload from private sources

Signed-off-by: Petr Vorel <pvorel@suse.cz>